### PR TITLE
Fix library being used from Service

### DIFF
--- a/library/src/main/java/app/akexorcist/bluetotohspp/library/BluetoothSPP.java
+++ b/library/src/main/java/app/akexorcist/bluetotohspp/library/BluetoothSPP.java
@@ -167,7 +167,7 @@ public class BluetoothSPP {
     }
     
     @SuppressLint("HandlerLeak")
-    private final Handler mHandler = new Handler() {
+    private final Handler mHandler = new Handler(Looper.getMainLooper()) {
         public void handleMessage(Message msg) {
             switch (msg.what) {
             case BluetoothState.MESSAGE_WRITE:


### PR DESCRIPTION
This is a patch for making the library work from outside the UI (such as Service, IntentService or BroadcastReceiver). Without it, the messages passed from the Service to the SPP class (via the handler) get lost.